### PR TITLE
[Issue#9] Mobile Banner Issue Resolved

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -16,11 +16,11 @@ const { banner, feature, services, workflow, call_to_action } = homepage.data;
     <div class="container">
       <div class="row text-center">
         <div class="mx-auto">
-          <h1 class="font-primary font-bold text-8xl text-white">{banner?.title}</h1>
+          <h1 class="font-primary font-bold text-4xl sm:text-8xl text-white">{banner?.title}</h1> <!-- Added breakpoint to resolve mobile banner issue. Any screens exceeding 640px in width will have 8xl font size -->
           <br />
           {
             banner?.content && (
-              <p class="mt-4 text-white text-4xl" set:html={markdownify(banner.content)} />
+              <p class="mt-4 text-white text-2xl sm:text-4xl" set:html={markdownify(banner.content)} />
             )
           }
         </div>


### PR DESCRIPTION
Added breakpoint to resolve the mobile banner issue.

- Used "sm" property.
- Any device whose screen width is greater than 640px  (Tablets and Laptops etc) will be shown the 8xl and 4xl font size of headings and paragraph respectively (As is currently being done)
- Any device whose screen width is less than 640px (Mobile phones) will be shown 4xl and 2xl font sizes for headings and paragraphs respectively.

Tested the above on localhost of mobile.

